### PR TITLE
Add window size menu tests

### DIFF
--- a/build/js/app.js
+++ b/build/js/app.js
@@ -1,2 +1,42 @@
-document.addEventListener("DOMContentLoaded",()=>{function e(){var e=window.innerWidth;desplegarMenu.style.display=e<=480?"block":"none"}navegador=document.querySelector("#nav"),desplegarMenu=document.querySelector("#abrir"),cerrarMenu=document.querySelector("#cerrar"),seleccionMenu=document.querySelectorAll("a"),desplegarMenu.addEventListener("click",()=>{navegador.classList.add("visible"),desplegarMenu.style.display="none"}),cerrarMenu.addEventListener("click",()=>{navegador.classList.remove("visible"),desplegarMenu.style.display="block"}),primerosCuatroEnlaces=Array.from(seleccionMenu).slice(0,4),seleccionMenu.forEach(e=>{e.addEventListener("click",()=>{navegador.classList.remove("visible"),desplegarMenu.style.display="block"})}),window.addEventListener("load",e),window.addEventListener("resize",e)});
+function verificarTamañoVentana(){
+    var tamañoVentana=window.innerWidth;
+    if(tamañoVentana<=480){
+        desplegarMenu.style.display="block";
+    }else{
+        desplegarMenu.style.display="none";
+    }
+}
+
+if(typeof document!="undefined"){
+document.addEventListener("DOMContentLoaded",()=>{
+    navegador=document.querySelector("#nav");
+    desplegarMenu=document.querySelector("#abrir");
+    cerrarMenu=document.querySelector("#cerrar");
+    seleccionMenu=document.querySelectorAll("a");
+
+    desplegarMenu.addEventListener("click",()=>{
+        navegador.classList.add("visible");
+        desplegarMenu.style.display="none";
+    });
+    cerrarMenu.addEventListener("click",()=>{
+        navegador.classList.remove("visible");
+        desplegarMenu.style.display="block";
+    });
+
+    primerosCuatroEnlaces=Array.from(seleccionMenu).slice(0,4);
+    seleccionMenu.forEach(seleccion=>{
+        seleccion.addEventListener("click",()=>{
+            navegador.classList.remove("visible");
+            desplegarMenu.style.display="block";
+        });
+    });
+
+    window.addEventListener("load",verificarTamañoVentana);
+    window.addEventListener("resize",verificarTamañoVentana);
+});
+}
+
+if(typeof module!="undefined"){
+    module.exports={verificarTamañoVentana:verificarTamañoVentana};
+}
 //# sourceMappingURL=app.js.map

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "sass": "^1.57.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,45 +1,51 @@
 
-document.addEventListener('DOMContentLoaded', () => {
+function verificarTamañoVentana() {
+    var tamañoVentana = window.innerWidth;
 
-    navegador = document.querySelector('#nav');
-    desplegarMenu = document.querySelector('#abrir');
-    cerrarMenu = document.querySelector('#cerrar');
-    seleccionMenu = document.querySelectorAll('a');
-
-
-
-    desplegarMenu.addEventListener('click', () => {
-        navegador.classList.add('visible');
-        desplegarMenu.style.display = "none";
-
-    })
-    cerrarMenu.addEventListener('click', () => {
-        navegador.classList.remove('visible');
+    if (tamañoVentana <= 480) {
         desplegarMenu.style.display = "block";
-    })
-    
-    primerosCuatroEnlaces = Array.from(seleccionMenu).slice(0, 4);
-    seleccionMenu.forEach(seleccion => {
-        seleccion.addEventListener('click', () => {
+    } else {
+        desplegarMenu.style.display = "none";
+    }
+}
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+
+        navegador = document.querySelector('#nav');
+        desplegarMenu = document.querySelector('#abrir');
+        cerrarMenu = document.querySelector('#cerrar');
+        seleccionMenu = document.querySelectorAll('a');
+
+
+
+        desplegarMenu.addEventListener('click', () => {
+            navegador.classList.add('visible');
+            desplegarMenu.style.display = "none";
+
+        })
+        cerrarMenu.addEventListener('click', () => {
             navegador.classList.remove('visible');
             desplegarMenu.style.display = "block";
         })
-    });
-    
 
-    
-    function verificarTamañoVentana() {
-        var tamañoVentana = window.innerWidth;
+        primerosCuatroEnlaces = Array.from(seleccionMenu).slice(0, 4);
+        seleccionMenu.forEach(seleccion => {
+            seleccion.addEventListener('click', () => {
+                navegador.classList.remove('visible');
+                desplegarMenu.style.display = "block";
+            })
+        });
 
-        if (tamañoVentana <= 480) {
-        desplegarMenu.style.display = "block";
-        } else {
-            desplegarMenu.style.display = "none";
-        }
-    }
 
-    // Llama a la función al cargar la página y cuando se redimensiona la ventana
-    window.addEventListener('load', verificarTamañoVentana);
-    window.addEventListener('resize', verificarTamañoVentana);
-})
+
+        // Llama a la función al cargar la página y cuando se redimensiona la ventana
+        window.addEventListener('load', verificarTamañoVentana);
+        window.addEventListener('resize', verificarTamañoVentana);
+    })
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { verificarTamañoVentana };
+}
 

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { verificarTamañoVentana } = require('../src/js/app');
+
+test('muestra el menú cuando el ancho es menor o igual a 480', () => {
+  global.window = { innerWidth: 480 };
+  global.desplegarMenu = { style: { display: 'none' } };
+  verificarTamañoVentana();
+  assert.strictEqual(global.desplegarMenu.style.display, 'block');
+});
+
+test('oculta el menú cuando el ancho es mayor a 480', () => {
+  global.window = { innerWidth: 800 };
+  global.desplegarMenu = { style: { display: 'block' } };
+  verificarTamañoVentana();
+  assert.strictEqual(global.desplegarMenu.style.display, 'none');
+});


### PR DESCRIPTION
## Summary
- export `verificarTamañoVentana` and guard DOM code for testability
- add tests validating menu display based on window width
- run tests via Node's built-in test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf70c9700832d90cf33b75d65b080